### PR TITLE
Display order state

### DIFF
--- a/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/App.js
+++ b/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/App.js
@@ -25,9 +25,8 @@ class App extends React.Component {
     addToOrder = key => {
         // Copy existing state
         const order = { ...this.state.order };
-        console.log(key);
         order[key] = order[key] + 1 || 1;
-        this.setState({order});
+        this.setState({ order });
     }
 
     render() {
@@ -36,10 +35,12 @@ class App extends React.Component {
                 <div className="menu">
                     <Header tagline="Fresh Seafood Market"></Header>
                     <ul className="fishes">
-                        {Object.keys(this.state.fishes).map(key => <Fish key={key} 
-                        index={key}
-                        details={this.state.fishes[key]} 
-                        addToOrder={this.addToOrder}/>)}
+                        {Object.keys(this.state.fishes).map(key => 
+                        <Fish 
+                            key={key} 
+                            index={key}
+                            details={this.state.fishes[key]} 
+                            addToOrder={this.addToOrder} />)}
                     </ul>
                 </div>
                 <Order fishes={this.state.fishes} order={this.state.order}></Order>

--- a/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/App.js
+++ b/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/App.js
@@ -42,7 +42,7 @@ class App extends React.Component {
                         addToOrder={this.addToOrder}/>)}
                     </ul>
                 </div>
-                <Order></Order>
+                <Order fishes={this.state.fishes} order={this.state.order}></Order>
                 <Inventory addFish={this.addFish} loadSampleFishes={this.loadSampleFishes}></Inventory>
             </div>
         )

--- a/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Fish.js
+++ b/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Fish.js
@@ -5,6 +5,7 @@ class Fish extends React.Component {
     handleClick = () => {
         this.props.addToOrder(this.props.index);
     }
+
     render() {
         const {image, name, price, desc, status} = this.props.details;
         const isAvailable = status === "available";

--- a/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Order.js
+++ b/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Order.js
@@ -1,5 +1,50 @@
 import React from "react";
+import { formatPrice } from "../helpers";
 
-const Order = () => <div className="Order">Order!!!</div>
+class Order extends React.Component {
+    renderOrder = (key) => {
+        const fish = this.props.fishes[key];
+        const count = this.props.order[key];
+        const isAvailable = fish.status === "available";
+        console.log(isAvailable)
+
+        if (!isAvailable) {
+            return <li>Sorry {fish ? fish.name : "fish"} is not available</li>;
+        }
+
+        return (
+            <li>
+            {count} lbs {fish.name}
+
+            {formatPrice(count * fish.price)}
+            </li>
+        );
+    };
+    render() {
+        const orderIds = Object.keys(this.props.order);
+        const total = orderIds.reduce((prevTotal, key) => {
+        const fish = this.props.fishes[key];
+        const count = this.props.order[key];
+        const isAvailable = fish && fish.status === "available";
+        
+        if (isAvailable) {
+            return prevTotal + count * fish.price;
+        }
+        
+        return prevTotal;
+    }, 0);
+
+        return (
+        <div className="order-wrap">
+            <h2>Order</h2>
+            <ul className="order">{orderIds.map(this.renderOrder)}</ul>
+            <div className="total">
+                Total:
+                <strong>{formatPrice(total)}</strong>
+            </div>
+        </div>
+        );
+    }
+}
 
 export default Order;

--- a/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Order.js
+++ b/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Order.js
@@ -2,18 +2,17 @@ import React from "react";
 import { formatPrice } from "../helpers";
 
 class Order extends React.Component {
-    renderOrder = (key) => {
+    renderOrder = key => {
         const fish = this.props.fishes[key];
         const count = this.props.order[key];
         const isAvailable = fish.status === "available";
-        console.log(isAvailable)
 
         if (!isAvailable) {
             return <li>Sorry {fish ? fish.name : "fish"} is not available</li>;
         }
 
         return (
-            <li>
+            <li key={key}>
             {count} lbs {fish.name}
 
             {formatPrice(count * fish.price)}
@@ -23,26 +22,28 @@ class Order extends React.Component {
     render() {
         const orderIds = Object.keys(this.props.order);
         const total = orderIds.reduce((prevTotal, key) => {
-        const fish = this.props.fishes[key];
-        const count = this.props.order[key];
-        const isAvailable = fish && fish.status === "available";
-        
-        if (isAvailable) {
-            return prevTotal + count * fish.price;
-        }
-        
-        return prevTotal;
+            const fish = this.props.fishes[key];
+            const count = this.props.order[key];
+            const isAvailable = fish && fish.status === "available";
+            
+            if (isAvailable) {
+                return prevTotal + (count * fish.price);
+            }
+            
+            return prevTotal;
     }, 0);
 
         return (
-        <div className="order-wrap">
-            <h2>Order</h2>
-            <ul className="order">{orderIds.map(this.renderOrder)}</ul>
-            <div className="total">
-                Total:
-                <strong>{formatPrice(total)}</strong>
+            <div className="order-wrap">
+                <h2>Order</h2>
+                <ul className="order">
+                    {orderIds.map(this.renderOrder)}
+                </ul>
+                <div className="total">
+                    Total:
+                    <strong>{formatPrice(total)}</strong>
+                </div>
             </div>
-        </div>
         );
     }
 }

--- a/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Order.js
+++ b/React-For-Beginners-Starter-Files/React-For-Beginners-Starter-Files-master/catch-of-the-day/src/components/Order.js
@@ -8,14 +8,17 @@ class Order extends React.Component {
         const isAvailable = fish.status === "available";
 
         if (!isAvailable) {
-            return <li>Sorry {fish ? fish.name : "fish"} is not available</li>;
+            return (
+                <li key={key}>
+                    Sorry {fish ? fish.name : "fish"} is not available
+                </li>
+            );
         }
 
         return (
             <li key={key}>
-            {count} lbs {fish.name}
-
-            {formatPrice(count * fish.price)}
+                {count} lbs {fish.name}
+                {formatPrice(count * fish.price)}
             </li>
         );
     };
@@ -27,11 +30,11 @@ class Order extends React.Component {
             const isAvailable = fish && fish.status === "available";
             
             if (isAvailable) {
-                return prevTotal + (count * fish.price);
+                return prevTotal + count * fish.price;
             }
             
             return prevTotal;
-    }, 0);
+        }, 0);
 
         return (
             <div className="order-wrap">


### PR DESCRIPTION
The display order state tutorial has been completed.

This covered:
- Passing down state using a spread
- Why you probably shouldn't pass down state entirely
- The reduce method (built-in)
- Making separate render functions when the original gets too big

Note: Part of the application isn't working - the bit where the product should show that it is no longer available in the order section of the menu.